### PR TITLE
Fix colon in file path for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1065,7 +1065,7 @@ async function pushCSV(data) {
     const opts = {
       owner,
       repo,
-      path: reportPath,
+      path: reportPath.replace(/:/g, '_'),
       message: `${new Date().toISOString().slice(0, 10)} Organization metrics report`,
       content: Buffer.from(csv).toString('base64'),
       committer: {
@@ -1111,7 +1111,7 @@ async function json(data) {
     const opts = {
       owner,
       repo,
-      path: reportPath,
+      path: reportPath.replace(/:/g, '_'),
       message: `${new Date().toISOString().slice(0, 10)} repo collaborator report`,
       content: Buffer.from(JSON.stringify(sortArray, null, 2)).toString('base64'),
       committer: {


### PR DESCRIPTION
When cloning a repo with reports :

![image](https://github.com/nicklegan/github-org-repo-metrics-action/assets/7974663/951a0bc2-7abd-48e3-9e92-93920ac12e57)

Windows doesn't like colons.